### PR TITLE
docs: add translation and fix a typo

### DIFF
--- a/docs/common-api/auth.rst
+++ b/docs/common-api/auth.rst
@@ -72,7 +72,7 @@ Common Structure of API Responses
    * - HTTP Headers
      - Values
    * - Status code
-     - API-specific HTTP-standard status codes. Responses commonly used throughout all APIs include 200, 201, 2014, 400, 401, 403, 404, 429, and 500, but not limited to.
+     - API-specific HTTP-standard status codes. Responses commonly used throughout all APIs include 200, 201, 204, 400, 401, 403, 404, 429, and 500, but not limited to.
    * - ``Content-Type``
      - ``application/json`` and its variants (e.g., ``application/problem+json`` for errors)
    * - ``Link``

--- a/docs/locales/ko_KR/LC_MESSAGES/common-api.po
+++ b/docs/locales/ko_KR/LC_MESSAGES/common-api.po
@@ -41,6 +41,8 @@ msgid ""
 "The server uses the API keys to identify each client and secret keys to "
 "verify integrity of API requests as well as to authenticate clients."
 msgstr ""
+"서버는 각 클라이언트를 식별하기 위해 API 키를 사용하며, "
+"클라이언트를 인증하고 API 요청의 무결성을 검증하기 위해 비밀 키를 사용합니다."
 
 #: ../../common-api/auth.rst:17
 msgid ""
@@ -49,6 +51,9 @@ msgid ""
 "server-side proxy to our API service if you are building a public-facing "
 "front-end service using Backend.AI."
 msgstr ""
+"만약 Backend.AI를 활용해 공개된 프론트엔드 서비스를 설계한다면, "
+"API 엑세스 키가 외부로 유출되는 등 발생할 수 있는 보안 문제를 예방하기 위해 "
+"API 서비스에 서버 사이드 프록시를 사용하는 것을 권장합니다."
 
 #: ../../common-api/auth.rst:21
 msgid ""
@@ -119,6 +124,9 @@ msgid ""
 "timezone is specified, UTC is assumed. The deviation with the server-side"
 " clock must be within 15-minutes."
 msgstr ""
+"요청의 날짜, 시간은 RFC 8022나 ISO 8601의 형식입니다. 만약 특별한 "
+"시간대가 명시되지 않았다면, UTC로 가정합니다. 서버의 시간과 요청의 시간의 "
+"차이는 15분 이내여야 합니다."
 
 #: ../../common-api/auth.rst:51
 msgid "``X-BackendAI-Date``"
@@ -162,7 +170,7 @@ msgstr ""
 
 #: ../../common-api/auth.rst:66
 msgid "Common Structure of API Responses"
-msgstr "API 응답들의 흔한 구조"
+msgstr "API 응답들의 일반적인 구조"
 
 #: ../../common-api/auth.rst:74
 msgid "Status code"
@@ -171,9 +179,12 @@ msgstr "상태 코드"
 #: ../../common-api/auth.rst:75
 msgid ""
 "API-specific HTTP-standard status codes. Responses commonly used "
-"throughout all APIs include 200, 201, 2014, 400, 401, 403, 404, 429, and "
+"throughout all APIs include 200, 201, 204, 400, 401, 403, 404, 429, and "
 "500, but not limited to."
 msgstr ""
+"API에 대한 HTTP 표준 상태 코드입니다. 모든 API에서 일반적으로 사용되는 "
+"응답에는 200, 201, 204, 400, 401, 403, 404, 429, 그리고 500이 포함되지만 "
+"이에 국한되지 않습니다."
 
 #: ../../common-api/auth.rst:77
 msgid ""
@@ -214,10 +225,13 @@ msgid ""
 "should generate a signing key derived from its API secret key and a "
 "string to sign by canonicalizing the HTTP request."
 msgstr ""
+"각각의 API 요청은 시그니처를 통해 서명되어야 합니다. 먼저, 클라이언트는 "
+"API 비밀 키에서 파생된 서명 키와 HTTP 요청을 정규화하여 얻을 수 있는 "
+"서명할 문자열을 생성해야 합니다."
 
 #: ../../common-api/auth.rst:93
 msgid "Generating a signing key"
-msgstr ""
+msgstr "서명 키 생성하기"
 
 #: ../../common-api/auth.rst:95
 msgid ""
@@ -225,22 +239,24 @@ msgid ""
 "The key is nestedly signed against the current date (without time) and "
 "the API endpoint address."
 msgstr ""
+"다음은 비밀 키에서 서명 키를 생성하는 Python 코드 입니다. 키는 현재 날짜 "
+"(시간 제외) 및 API 엔드포인트 주소에 대해 중첩 서명 됩니다."
 
 #: ../../common-api/auth.rst:116
 msgid "Generating a string to sign"
-msgstr ""
+msgstr "서명할 문자열 생성하기"
 
 #: ../../common-api/auth.rst:118
 msgid "The string to sign is generated from the following request-related values:"
-msgstr ""
+msgstr "서명할 문자열은 다음과 같은 요청 정보 값에 의해 생성됩니다."
 
 #: ../../common-api/auth.rst:120
 msgid "HTTP Method (uppercase)"
-msgstr ""
+msgstr "HTTP 메서드 (대문자)"
 
 #: ../../common-api/auth.rst:121
 msgid "URI including query strings"
-msgstr ""
+msgstr "쿼리 문자열을 포함한 URI"
 
 #: ../../common-api/auth.rst:122
 msgid ""
@@ -248,24 +264,29 @@ msgid ""
 "present) formatted in ISO 8601 (``YYYYmmddTHHMMSSZ``) using the UTC "
 "timezone."
 msgstr ""
+"UTC 시간대를 활용하고 ISO 8601 형식으로 구성된 (``YYYYmmddTHHMMSSZ``) "
+"``Date`` 의 값 (단, 요청에서 ``Date`` 가 주어지지 않았다면, "
+"``X-BackendAI-Date`` 를 사용함.)"
 
 #: ../../common-api/auth.rst:123
 msgid "The canonicalized header/value pair of ``Host``"
-msgstr ""
+msgstr "정규화 된 ``Host`` 의 헤더/값 쌍"
 
 #: ../../common-api/auth.rst:124
 msgid "The canonicalized header/value pair of ``Content-Type``"
-msgstr ""
+msgstr "정규화 된 ``Content-Type`` 의 헤더/값 쌍"
 
 #: ../../common-api/auth.rst:125
 msgid "The canonicalized header/value pair of ``X-BackendAI-Version``"
-msgstr ""
+msgstr "정규화 된 ``X-BackendAI-Version`` 의 헤더/값 쌍"
 
 #: ../../common-api/auth.rst:126
 msgid ""
 "The hex-encoded hash value of body as-is. The hash function must be same "
 "to the one given in the ``Authorization`` header (e.g., SHA256)."
 msgstr ""
+"body 전체를 hex로 인코딩한 hash 값. 사용한 hash 함수는 반드시 "
+"``Authorization`` 헤더에 명시된 함수와 동일해야 합니다. (e.g., SHA256)."
 
 #: ../../common-api/auth.rst:128
 msgid ""
@@ -277,12 +298,21 @@ msgid ""
 "9) of its value, and join the lowercased header name and the value with a"
 " single colon (``\":\"``, ASCII 58) character."
 msgstr ""
+"서명할 문자열을 생성하기 위해, 클라이언트는 위의 값들을 newline 문자열 "
+"(``\"\\n\"``, ASCII 10) 을 활용하여 합쳐야 합니다. 모든 non-ASCII 문자열은 "
+"반드시 UTF-8 형식으로 인코딩 되어야 합니다. HTTP 헤더/값 쌍을 정규화 하기 위해선, "
+"먼저 맨 앞이나 맨 뒤에 붙어있는 공백 문자열 (``\"\\n\"``, ``\"\\r\"``, "
+"``\" \"``, ``\"\\t\"``; 또는 ASCII 10, 13, 32, 9) 을 제거해야 하며, "
+"소문자로 변경된 헤더의 이름과 값을 콜론 (``\":\"``, ASCII 58) 문자열을 통해 "
+"연결해야 합니다."
 
 #: ../../common-api/auth.rst:132
 msgid ""
 "The success example in `Example Requests and Responses`_ makes a string "
 "to sign as follows (where the newlines are ``\"\\n\"``):"
 msgstr ""
+"`요청과 응답 예시` 에 적힌 예시는 다음과 같은 방식으로 서명할 문자열을 "
+"생성 하였습니다."
 
 #: ../../common-api/auth.rst:144
 msgid ""
@@ -290,46 +320,52 @@ msgid ""
 " string using the SHA256 hash function since there is no body for GET "
 "requests."
 msgstr ""
+"이 예시에서, GET 요청의 body 부분이 비어있기 때문에 SHA256 hash 함수를 사용하여 "
+"빈 문자열로 부터 ``e3b0c4...`` 라는 hash 값을 얻었습니다."
 
 #: ../../common-api/auth.rst:146
 msgid ""
 "Then, the client should calculate the signature using the derived signing"
 " key and the generated string with the hash function, as follows:"
 msgstr ""
+"그리고, 클라이언트는 서명 키와 hash 함수로 부터 생성된 문자열을 활용해 "
+"다음과 같이 시그니쳐를 계산해야 합니다."
 
 #: ../../common-api/auth.rst:159
 msgid "Attaching the signature"
-msgstr ""
+msgstr "시그니쳐 삽입"
 
 #: ../../common-api/auth.rst:161
 msgid ""
 "Finally, the client now should construct the following HTTP "
 "``Authorization`` header:"
 msgstr ""
+"마지막으로, 클라이언트는 이제 ``Authorization`` HTTP 헤더를 "
+"구성해야 합니다."
 
 #: ../../common-api/auth.rst:169
 msgid "Example Requests and Responses"
-msgstr ""
+msgstr "요청과 응답 예시"
 
 #: ../../common-api/auth.rst:171
 msgid "For the examples here, we use a dummy access key and secret key:"
-msgstr ""
+msgstr "이 예시에서, 우리는 다음과 같은 더미 엑세스 키와 비밀 키를 사용할 것 입니다."
 
 #: ../../common-api/auth.rst:173
 msgid "Example access key: ``AKIAIOSFODNN7EXAMPLE``"
-msgstr ""
+msgstr "엑세스 키 예시: ``AKIAIOSFODNN7EXAMPLE``"
 
 #: ../../common-api/auth.rst:174
 msgid "Example secret key: ``wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY``"
-msgstr ""
+msgstr "비밀 키 예시: ``wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY``"
 
 #: ../../common-api/auth.rst:177
 msgid "Success example for checking the latest API version"
-msgstr ""
+msgstr "최신 API 버전을 확인하는 예시"
 
 #: ../../common-api/auth.rst:204
 msgid "Failure example with a missing authorization header"
-msgstr ""
+msgstr "authorization 헤더를 포함하지 않아 발생하는 실패 예시"
 
 #: ../../common-api/convention.rst:2
 msgid "API and Document Conventions"

--- a/docs/locales/ko_KR/LC_MESSAGES/index.po
+++ b/docs/locales/ko_KR/LC_MESSAGES/index.po
@@ -28,7 +28,7 @@ msgstr "클러스터 설치"
 
 #: ../../index.rst:40
 msgid "Client SDK"
-msgstr ""
+msgstr "클라이언트 SDK"
 
 #: ../../index.rst:48
 msgid "API Common Reference"
@@ -36,11 +36,11 @@ msgstr ""
 
 #: ../../index.rst:59
 msgid "User API Reference"
-msgstr ""
+msgstr "유저 API 레퍼런스"
 
 #: ../../index.rst:75
 msgid "Admin API Reference"
-msgstr ""
+msgstr "관리자 API 레퍼런스"
 
 #: ../../index.rst:87
 msgid "Developer Manuals"
@@ -48,7 +48,7 @@ msgstr "개발자 매뉴얼"
 
 #: ../../index.rst:7
 msgid "Backend.AI API Documentation"
-msgstr ""
+msgstr "Backend.AI API 문서"
 
 #: ../../index.rst:9
 msgid "**Latest API version: v4.20190315**"
@@ -60,6 +60,9 @@ msgid ""
 "deployment. It runs arbitrary user codes safely in resource-constrained "
 "environments, using Docker and our own sandbox wrapper."
 msgstr ""
+"Backend.AI는 AI 모델 개발 및 배포를 위한 '불편하지 않은' 백엔드 입니다. "
+"Backend.AI는 Docker나 자체적인 샌드박스 래퍼 같은 자원 제한적인 환경에서 "
+"특정 코드를 동작 시킵니다."
 
 #: ../../index.rst:14
 msgid ""
@@ -68,6 +71,9 @@ msgid ""
 "as well as AI-oriented libraries such as TensorFlow, Keras, Caffe, and "
 "MXNet."
 msgstr ""
+"Backend.AI는 Python 2/3, R, PHP, C/C++, Java, Javascript, Julia, Octave, "
+"Haskell, Lua, 그리고 NodeJS 등의 다양한 프로그래밍 언어와 런타임을 지원하며, "
+"TensorFlow, Keras, Caffe, MXNet 등의 AI 라이브러리를 지원합니다."
 
 #: ../../index.rst:17
 msgid "Table of Contents"


### PR DESCRIPTION
### fix

docs/common-api/auth.rst에 오타가 존재하여 수정하였습니다. 

**before**
```
Responses commonly used throughout all APIs include 200, 201, 2014, 400, 401, 403, 404, 429, and 500, but not limited to.
```

**after**
```
Responses commonly used throughout all APIs include 200, 201, 204, 400, 401, 403, 404, 429, and 500, but not limited to.
```

---

### add
common-api/auth.rst와 index.rst에 대한 번역 작업을 진행하였습니다.